### PR TITLE
Add support for logits in metrics

### DIFF
--- a/basars_addons/metrics/confusion_matrix.py
+++ b/basars_addons/metrics/confusion_matrix.py
@@ -5,12 +5,18 @@ from tensorflow.keras.metrics import Precision, Recall
 
 class ThresholdPrecision(Precision):
 
-    def __init__(self, threshold=0.5, thresholds=None, top_k=None, class_id=None, name=None, dtype=None):
+    def __init__(self,
+                 threshold=0.5, thresholds=None, top_k=None, class_id=None, from_logits=False,
+                 name=None, dtype=None):
         super(ThresholdPrecision, self).__init__(thresholds, top_k, class_id, name, dtype)
 
         self.threshold = threshold
+        self.from_logits = from_logits
 
     def update_state(self, y_true, y_pred, sample_weight=None):
+        if self.from_logits:
+            y_pred = tf.nn.softmax(y_pred, axis=-1)
+
         y_pred = tf.cast(y_pred >= self.threshold, self._dtype)
 
         super(ThresholdPrecision, self).update_state(y_true, y_pred, sample_weight=sample_weight)
@@ -18,12 +24,18 @@ class ThresholdPrecision(Precision):
 
 class ThresholdRecall(Recall):
 
-    def __init__(self, threshold=0.5, thresholds=None, top_k=None, class_id=None, name=None, dtype=None):
+    def __init__(self,
+                 threshold=0.5, thresholds=None, top_k=None, class_id=None, from_logits=False,
+                 name=None, dtype=None):
         super(ThresholdRecall, self).__init__(thresholds, top_k, class_id, name, dtype)
 
         self.threshold = threshold
+        self.from_logits = from_logits
 
     def update_state(self, y_true, y_pred, sample_weight=None):
+        if self.from_logits:
+            y_pred = tf.nn.softmax(y_pred, axis=-1)
+
         y_pred = tf.cast(y_pred >= self.threshold, self._dtype)
 
         super(ThresholdRecall, self).update_state(y_true, y_pred, sample_weight=sample_weight)

--- a/basars_addons/metrics/intersection_over_union.py
+++ b/basars_addons/metrics/intersection_over_union.py
@@ -5,12 +5,16 @@ from tensorflow.keras.metrics import MeanIoU
 
 class ThresholdBinaryIoU(MeanIoU):
 
-    def __init__(self, num_classes, threshold=0.5, name=None, dtype=None):
+    def __init__(self, num_classes, threshold=0.5, from_logits=False, name=None, dtype=None):
         super(ThresholdBinaryIoU, self).__init__(num_classes=num_classes, name=name, dtype=dtype)
 
         self.threshold = threshold
+        self.from_logits = from_logits
 
     def update_state(self, y_true, y_pred, sample_weight=None):
+        if self.from_logits:
+            y_pred = tf.nn.softmax(y_pred, axis=-1)
+
         y_pred = tf.cast(y_pred >= self.threshold, self._dtype)
 
         super(ThresholdBinaryIoU, self).update_state(y_true, y_pred, sample_weight=sample_weight)


### PR DESCRIPTION
# Add softmax distribution to metrics

- ThresholdBinaryIoU
- ThresholdPrecision
- ThresholdRecall

All metrics are capable with 0-1 normalized targets.
However, there are some cases that must be normalized.
The new argument `from_logits=True` is for that.