### PR TITLE
Fix cosine decay type mismatch

### DIFF
--- a/basars_addons/schedules/cosine_decay.py
+++ b/basars_addons/schedules/cosine_decay.py
@@ -43,6 +43,8 @@ class CosineDecayWarmupRestarts(CosineDecayRestarts):
         self.first_cycle_steps = first_cycle_steps
 
     def __call__(self, step):
+        step = tf.cast(step, tf.float32)
+
         stage1 = tf.cast(step > self.first_cycle_steps, tf.float32)
         stage2 = tf.cast(step <= self.first_cycle_steps, tf.float32)
         annealing = super(CosineDecayWarmupRestarts, self).__call__(step - self.first_cycle_steps) * stage1

--- a/tests/schedules/cosine_decay_test.py
+++ b/tests/schedules/cosine_decay_test.py
@@ -1,0 +1,25 @@
+import pytest
+
+import tensorflow as tf
+
+from basars_addons.schedules import CosineDecayWarmupRestarts, InitialCosineDecayRestarts
+
+
+def test_initial_cosine_decay_type_mismatch():
+    scheduler = InitialCosineDecayRestarts(0, 1e-3, 300, 1.0)
+
+    epoch = tf.constant(1, dtype=tf.int64)
+    learning_rate = scheduler(epoch)
+    assert learning_rate.numpy() > 0.
+
+
+def test_cosine_decay_warmup_type_mismatch():
+    scheduler = CosineDecayWarmupRestarts(100, 1e-3, 300, 1.0)
+
+    epoch = tf.constant(1, dtype=tf.int64)
+    learning_rate = scheduler(epoch)
+    assert learning_rate.numpy() > 0.
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
# Cosine Decay Schedulers Type Mismatch While Training

In previous code, TensorFlow throws an error when `CosineDecayWarmupRestarts`.
```
TypeError: Cannot convert 100.0 to EagerTensor of type int64
```
The reason was the `step` from `__call__` function is typed as `EagerTensor of type int64`.
Updated code casts the `step` as `tf.float32` to avoid the error.